### PR TITLE
Allow plugin to work anywhere in Scene Tree

### DIFF
--- a/generator.gd
+++ b/generator.gd
@@ -113,7 +113,7 @@ func set_polygons_on_colliders() -> void:
 			polygon_shape.name = "TMCG-CollisionPolygon2D-"+str(count)
 			count += 1
 			add_child(polygon_shape)
-			polygon_shape.owner = get_parent()
+			polygon_shape.owner = get_tree().edited_scene_root
 		print("Added " + str(len(polygons)) + "(s) unique polygons.")
 
 func get_points(position: Vector2, cell_size: Vector2) -> Array:


### PR DESCRIPTION
I ran into a small issue while using this plugin, where it worked fine when the `TileMapCollisionGenerator` node was a child of the root node, it would work fine, but if it was the child of any other node, it would fail to actually create and show the `CollisionPolygon2D` in the editor's Scene Tree.

I found that changing this one line of code to change the owner to `get_tree().edited_scene_root` fixed the issue for me, working both as a child of the root and a child of a child.

I also noticed a [similar plugin](https://github.com/popcar2/GodotTilemapBaker/blob/2b27c933a835fd7f5d8096de9d3aba92f1f6d13a/TilemapCollisionBaker.gd#L137) doing this same thing.

Please consider this PR. Cheers :)